### PR TITLE
#23 Consistent Dependencies

### DIFF
--- a/src/main/scala/com/typelead/Cabal.scala
+++ b/src/main/scala/com/typelead/Cabal.scala
@@ -1,7 +1,7 @@
 package com.typelead
 
 import sbt._
-import EtaDependency.EtaVersion
+import EtaDependency.{EtaPackage, EtaVersion}
 
 final case class Cabal(projectName: String,
                        projectVersion: String,
@@ -98,8 +98,6 @@ object Cabal {
     executables = Nil,
     testSuites = Nil
   )
-
-  final case class EtaPackage(name: String, jars: Seq[File], packageDb: File)
 
   object TestSuiteTypes extends Enumeration {
     val exitcode: Value = Value("exitcode-stdio-1.0")

--- a/src/main/scala/com/typelead/EtaDependency.scala
+++ b/src/main/scala/com/typelead/EtaDependency.scala
@@ -32,6 +32,8 @@ object EtaDependency {
     }
   }
 
+  final case class EtaPackage(name: String, jars: Seq[File], packageDb: File)
+
   // Eta version
 
   final case class EtaVersion(private val underlying: String) {

--- a/src/main/scala/com/typelead/EtaDependency.scala
+++ b/src/main/scala/com/typelead/EtaDependency.scala
@@ -32,7 +32,10 @@ object EtaDependency {
     }
   }
 
-  final case class EtaPackage(name: String, jars: Seq[File], packageDb: File)
+  final case class EtaPackage(cabal: Cabal, jars: Seq[File], packageDb: File) {
+    val name: String = cabal.projectName
+    val version: String = cabal.projectVersion
+  }
 
   // Eta version
 

--- a/src/main/scala/com/typelead/Etlas.scala
+++ b/src/main/scala/com/typelead/Etlas.scala
@@ -111,16 +111,6 @@ final case class Etlas(installPath: Option[File], workDir: File, dist: File, eta
     }
   }
 
-  def getSupported(log: Logger): Etlas.Supported = {
-    etlas(installPath, args("exec", "eta", "--", "--supported-extensions"), workDir, log, saveOutput = true)
-      .foldLeft(Etlas.Supported(Nil, Nil)) {
-        case (Etlas.Supported(languages, extensions), str) if str.startsWith("Haskell") =>
-          Etlas.Supported(languages :+ str, extensions)
-        case (Etlas.Supported(languages, extensions), str) =>
-          Etlas.Supported(languages, extensions :+ str)
-      }
-  }
-
   // Resolve dependencies
 
   def getMavenDependencies(cabal: Cabal, log: Logger, filter: Cabal.Artifact.Filter): Seq[ModuleID] = {
@@ -230,6 +220,16 @@ object Etlas {
 
   def etlasVersion(installPath: Option[File], workDir: File, log: Logger): String = {
     etlas(installPath, Seq("--numeric-version"), workDir, log, saveOutput = true).head
+  }
+
+  def etaSupported(installPath: Option[File], workDir: File, etaVersion: EtaVersion, log: Logger): Supported = {
+    etlas(installPath, Seq("exec", "eta", "--", "--supported-extensions").withEtaVersion(etaVersion), workDir, log, saveOutput = true)
+      .foldLeft(Etlas.Supported(Nil, Nil)) {
+        case (Etlas.Supported(languages, extensions), str) if str.startsWith("Haskell") =>
+          Etlas.Supported(languages :+ str, extensions)
+        case (Etlas.Supported(languages, extensions), str) =>
+          Etlas.Supported(languages, extensions :+ str)
+      }
   }
 
   private[typelead] val DEFAULT_ETLAS_REPO = "http://cdnverify.eta-lang.org/eta-binaries"

--- a/src/main/scala/com/typelead/SbtEta.scala
+++ b/src/main/scala/com/typelead/SbtEta.scala
@@ -75,7 +75,7 @@ object SbtEta extends AutoPlugin {
     inThisBuild(Seq(
       etaSendMetrics := true,
       etlasUseLocal := true,
-      etlasPath := baseDirectory.value / "project" / "target" / "etlas" / "etlas",
+      etlasPath := BuildPaths.outputDirectory(BuildPaths.projectStandard(baseDirectory.value)) / "etlas" / "etlas",
       etlasRepository := Etlas.DEFAULT_ETLAS_REPO,
       etlasVersion := {
         val installPath = if (etlasUseLocal.value) None else Some(etlasPath.value)


### PR DESCRIPTION
This pull request contains:

- `etlas freeze` for consistent dependencies resolving;
- validation for `default-language` and `default-extensions` values;
- command `eta-languages` for show all available languages;
- command `eta-extensions` for show all available extensions;
- some code refactoring.
